### PR TITLE
HA-114: adapt flutter blue

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,15 @@
 </p>
 <br><br>
 
+# NOTE - about this fork of FlutterBlue
+
+This fork of FlutterBlue introduces two main changes: allowing duplicate
+devices when BLE scanning (by setting
+`CBCentralManagerScanOptionAllowDuplicatesKey` to `YES`), and *only*
+emitting characteristic values after they have been changed. This allows
+us to not care about the cached value of the characteristic which is
+read upon service discovery.
+
 ## Introduction
 
 FlutterBlue is a bluetooth plugin for [Flutter](http://www.flutter.io), a new mobile SDK to help developers build modern apps for iOS and Android.

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -78,4 +78,5 @@ protobuf {
 
 dependencies {
     implementation 'com.google.protobuf:protobuf-lite:3.0.1'
+    implementation 'androidx.core:core:1.1.0'
 }

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -3,5 +3,5 @@
 
   <uses-permission android:name="android.permission.BLUETOOTH" />
   <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" />
-  <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>
+  <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
 </manifest>

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
   package="com.pauldemarco.flutter_blue">
-  <uses-sdk android:minSdkVersion="18" />
+
   <uses-permission android:name="android.permission.BLUETOOTH" />
   <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" />
   <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>

--- a/android/src/main/java/com/pauldemarco/flutter_blue/FlutterBluePlugin.java
+++ b/android/src/main/java/com/pauldemarco/flutter_blue/FlutterBluePlugin.java
@@ -57,7 +57,7 @@ import io.flutter.plugin.common.PluginRegistry.RequestPermissionsResultListener;
 public class FlutterBluePlugin implements MethodCallHandler, RequestPermissionsResultListener  {
     private static final String TAG = "FlutterBluePlugin";
     private static final String NAMESPACE = "plugins.pauldemarco.com/flutter_blue";
-    private static final int REQUEST_COARSE_LOCATION_PERMISSIONS = 1452;
+    private static final int REQUEST_FINE_LOCATION_PERMISSIONS = 1452;
     static final private UUID CCCD_ID = UUID.fromString("00002902-0000-1000-8000-00805f9b34fb");
     private final Registrar registrar;
     private final Activity activity;
@@ -147,14 +147,14 @@ public class FlutterBluePlugin implements MethodCallHandler, RequestPermissionsR
 
             case "startScan":
             {
-                if (ContextCompat.checkSelfPermission(activity, Manifest.permission.ACCESS_COARSE_LOCATION)
+                if (ContextCompat.checkSelfPermission(activity, Manifest.permission.ACCESS_FINE_LOCATION)
                         != PackageManager.PERMISSION_GRANTED) {
                     ActivityCompat.requestPermissions(
                             activity,
                             new String[] {
-                                    Manifest.permission.ACCESS_COARSE_LOCATION
+                                    Manifest.permission.ACCESS_FINE_LOCATION
                             },
-                            REQUEST_COARSE_LOCATION_PERMISSIONS);
+                            REQUEST_FINE_LOCATION_PERMISSIONS);
                     pendingCall = call;
                     pendingResult = result;
                     break;
@@ -547,7 +547,7 @@ public class FlutterBluePlugin implements MethodCallHandler, RequestPermissionsR
     @Override
     public boolean onRequestPermissionsResult(
             int requestCode, String[] permissions, int[] grantResults) {
-        if (requestCode == REQUEST_COARSE_LOCATION_PERMISSIONS) {
+        if (requestCode == REQUEST_FINE_LOCATION_PERMISSIONS) {
             if (grantResults[0] == PackageManager.PERMISSION_GRANTED) {
                 startScan(pendingCall, pendingResult);
             } else {

--- a/ios/Classes/FlutterBluePlugin.m
+++ b/ios/Classes/FlutterBluePlugin.m
@@ -95,7 +95,8 @@ typedef NS_ENUM(NSUInteger, LogLevel) {
       uuids = [uuids arrayByAddingObject:[CBUUID UUIDWithString:u]];
     }
     // TODO: iOS Scan Options (#35)
-    [self->_centralManager scanForPeripheralsWithServices:uuids options:nil];
+    NSDictionary *scanningOptions = @{CBCentralManagerScanOptionAllowDuplicatesKey: @YES};
+    [self->_centralManager scanForPeripheralsWithServices:uuids options:scanningOptions];
     result(nil);
   } else if([@"stopScan" isEqualToString:call.method]) {
     [self->_centralManager stopScan];

--- a/lib/src/bluetooth_characteristic.dart
+++ b/lib/src/bluetooth_characteristic.dart
@@ -54,8 +54,6 @@ class BluetoothCharacteristic {
           .map((c) {
         // Update the characteristic with the new values
         _updateDescriptors(c.descriptors);
-//        _value.add(c.lastValue);
-//        print('c.lastValue: ${c.lastValue}');
         return c;
       });
 

--- a/lib/src/bluetooth_characteristic.dart
+++ b/lib/src/bluetooth_characteristic.dart
@@ -40,7 +40,7 @@ class BluetoothCharacteristic {
             .map((d) => new BluetoothDescriptor.fromProto(d))
             .toList(),
         properties = new CharacteristicProperties.fromProto(p.properties),
-        _value = BehaviorSubject.seeded(p.value);
+        _value = p.value.isEmpty ? BehaviorSubject() : BehaviorSubject.seeded(p.value);
 
   Stream<BluetoothCharacteristic> get _onCharacteristicChangedStream =>
       FlutterBlue.instance._methodStream


### PR DESCRIPTION
This PR includes a few changes:

* Fixed BLE scanning for targetApi 29
* Emitting duplicate devices when BLE scanning on iOS
* Only listening to characteristic values when they change
* Filtering out empty characteristic values

☝️ I'm a little unsure about the last one. Without the filter, we will immediately emit a characteristic value after connecting (since the characteristic will be initialized with an empty value). But maybe we want to be able to send empty values? I could potentially hack myself around this by introducing nulls somewhere...